### PR TITLE
Improve config module

### DIFF
--- a/src/config.gleam
+++ b/src/config.gleam
@@ -1,5 +1,4 @@
 import glaml.{type DocNode}
-import gleam/dict
 import gleam/int
 import gleam/list
 import gleam/result
@@ -14,7 +13,6 @@ pub type Website {
 }
 
 pub type ConfigError {
-  ConfigError(message: String)
   ReadError
   ParseError
   MissingKey(which: String)

--- a/src/config.gleam
+++ b/src/config.gleam
@@ -70,17 +70,18 @@ pub fn parse_config_file(data: String) -> Result(List(Website), ConfigError) {
             })
 
           let d = dict.from_list(tuples)
-          let interval = case
-            int.base_parse(get_dict_optional_key(d, "interval"), 10)
-          {
-            Ok(value) -> value
-            Error(_) -> 10
-          }
 
           Website(
-            url: get_dict_optional_key(d, "url"),
-            interval: interval,
-            pattern: get_dict_optional_key(d, "pattern"),
+            url: d
+              |> dict.get("url")
+              |> result.unwrap(""),
+            interval: d
+              |> dict.get("interval")
+              |> result.then(int.parse)
+              |> result.unwrap(or: 10),
+            pattern: d
+              |> dict.get("pattern")
+              |> result.unwrap(""),
           )
         }
         _ -> Website(url: "", interval: 0, pattern: "")
@@ -89,13 +90,6 @@ pub fn parse_config_file(data: String) -> Result(List(Website), ConfigError) {
     |> list.filter(fn(w) { w.url != "" })
 
   Ok(websites)
-}
-
-fn get_dict_optional_key(d: dict.Dict(String, String), key: String) -> String {
-  case d |> dict.get(key) {
-    Ok(value) -> value
-    Error(_) -> ""
-  }
 }
 
 fn require_doc_node_seq(

--- a/src/config.gleam
+++ b/src/config.gleam
@@ -22,15 +22,10 @@ pub type ConfigError {
 }
 
 pub fn load(filename: String) -> Result(Config, ConfigError) {
-  use file_data <- result.try(open_config_file(filename))
-  use websites <- result.try(parse_config_file(file_data))
-
-  Ok(Config(websites))
-}
-
-fn open_config_file(filename: String) -> Result(String, ConfigError) {
   simplifile.read(filename)
   |> result.replace_error(ReadError)
+  |> result.then(parse_config_file)
+  |> result.map(Config)
 }
 
 pub fn parse_config_file(data: String) -> Result(List(Website), ConfigError) {

--- a/src/websites_checker.gleam
+++ b/src/websites_checker.gleam
@@ -1,6 +1,4 @@
-import config.{
-  ConfigError, InvalidFileFormat, MissingWebsitesKey, ParseError, ReadError,
-}
+import config.{ConfigError, InvalidFileFormat, MissingKey, ParseError, ReadError}
 import crawler
 import database
 import gleam/erlang/os
@@ -28,9 +26,9 @@ pub fn main() {
       let message = case error {
         ConfigError(message) -> message
         ParseError -> "Failed to parse config file"
-        MissingWebsitesKey -> "websites key not found in config file"
+        MissingKey(which) -> which <> " key not found in config file"
         ReadError -> "Failed to read config file"
-        InvalidFileFormat -> "Invalid config file format"
+        InvalidFileFormat | config.InvalidValue -> "Invalid config file format"
       }
       panic as { "Failed to load config: " <> message }
     }

--- a/src/websites_checker.gleam
+++ b/src/websites_checker.gleam
@@ -1,4 +1,6 @@
-import config
+import config.{
+  ConfigError, InvalidFileFormat, MissingWebsitesKey, ParseError, ReadError,
+}
 import crawler
 import database
 import gleam/erlang/os
@@ -22,7 +24,16 @@ pub fn main() {
       ))
       config
     }
-    Error(e) -> panic as string.append("Failed to load config: ", e.message)
+    Error(error) -> {
+      let message = case error {
+        ConfigError(message) -> message
+        ParseError -> "Failed to parse config file"
+        MissingWebsitesKey -> "websites key not found in config file"
+        ReadError -> "Failed to read config file"
+        InvalidFileFormat -> "Invalid config file format"
+      }
+      panic as { "Failed to load config: " <> message }
+    }
   }
 
   // Run database migrations

--- a/src/websites_checker.gleam
+++ b/src/websites_checker.gleam
@@ -1,4 +1,4 @@
-import config.{ConfigError, InvalidFileFormat, MissingKey, ParseError, ReadError}
+import config.{InvalidFileFormat, MissingKey, ParseError, ReadError}
 import crawler
 import database
 import gleam/erlang/os
@@ -24,7 +24,6 @@ pub fn main() {
     }
     Error(error) -> {
       let message = case error {
-        ConfigError(message) -> message
         ParseError -> "Failed to parse config file"
         MissingKey(which) -> which <> " key not found in config file"
         ReadError -> "Failed to read config file"


### PR DESCRIPTION
This applies some simplification ideas and reduces indentation in the parse function.

This also introduce specific error variants to keep display stuff out of parsing logic. Also, this now fails instead of ignoring invalid websites configs.